### PR TITLE
Update status page texts

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -17,8 +17,8 @@ status-website:
   # baseUrl: /upptime
   logoUrl: https://raw.githubusercontent.com/upptime/upptime.js.org/master/static/img/icon.svg
   name: Upptime
-  introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
-  introMessage: This is a sample status page which uses **real-time** data from our [GitHub repository](https://github.com/upptime/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/upptime/upptime)
+  introTitle: "Status page for my sites"
+  introMessage: This is the status page for my sites powered by Upptime.  [**Get your own for free**](https://github.com/upptime/upptime)
   navbar:
     - title: Status
       href: /


### PR DESCRIPTION
The previous text represent upptime's defaults. These do not fit with the custom status page at all.